### PR TITLE
Fix a bug that prevents god from getting players

### DIFF
--- a/DevAAC/routes/players.php
+++ b/DevAAC/routes/players.php
@@ -409,7 +409,7 @@ $DevAAC->get(ROUTES_API_PREFIX.'/players', function() use($DevAAC) {
         }
         $players->select($fields);
     }
-    elseif(!$DevAAC->auth_account || !$DevAAC->auth_account->isGod())
+    else
         $players->select($visible);
 
     if(intval($req->get('offset')))


### PR DESCRIPTION
When someone is logged in to a god account, he won't be able to get players using GET /players API call.

This pull request fixes this bug.